### PR TITLE
Change TO_NUMBER to RECIPIENT_NUMBER in Verify

### DIFF
--- a/src/main/java/com/nexmo/quickstart/verify/StartVerification.java
+++ b/src/main/java/com/nexmo/quickstart/verify/StartVerification.java
@@ -34,11 +34,11 @@ public class StartVerification {
 
         String NEXMO_API_KEY = envVar("NEXMO_API_KEY");
         String NEXMO_API_SECRET = envVar("NEXMO_API_SECRET");
-        String TO_NUMBER = envVar("TO_NUMBER");
+        String RECIPIENT_NUMBER = envVar("RECIPIENT_NUMBER");
 
 
         NexmoClient client = new NexmoClient.Builder().apiKey(NEXMO_API_KEY).apiSecret(NEXMO_API_SECRET).build();
-        VerifyResponse response = client.getVerifyClient().verify(TO_NUMBER, "NEXMO");
+        VerifyResponse response = client.getVerifyClient().verify(RECIPIENT_NUMBER, "NEXMO");
 
         if (response.getStatus() == VerifyStatus.OK) {
             System.out.printf("RequestID: %s", response.getRequestId());


### PR DESCRIPTION
Changed in the `StartVerification.java` example.

As discussed in [this Slack thread](https://nexmo.slack.com/archives/GCYA1C6UE/p1542800167041000), we want to use `RECIPIENT_NUMBER` instead of `NEXMO_TO_NUMBER`.

[DEVX-640](https://nexmoinc.atlassian.net/browse/DEVX-640) ticket raised to change this across all building blocks.